### PR TITLE
Add `to_xarray` method for drive object 

### DIFF
--- a/micromagneticdata/drive.py
+++ b/micromagneticdata/drive.py
@@ -418,7 +418,57 @@ class Drive:
         )
 
     def to_xarray(self):
-        """Export ``micromagneticdata.Drive`` as ``xarray.Dataset``"""
+        """Export ``micromagneticdata.Drive`` as ``xarray.DataArray``
+
+        The method depends on ``discretisedfield.Field.to_xarray()`` and derives the
+        last four dimensions ``x``, ``y``, ``z``, and ``comp`` in the output
+        ``xarray.DataArray`` from it.
+
+        Depending on ``micromagneticdata.Drive.info['driver']``, the dimensions and
+        coordinates of the output changes. For ``MinDriver``, which only contains a
+        single ``discretisedfield.Field``, the value of the single
+        ``discretisedfield.Field.to_xarray()`` is returned. For ``TimeDriver``, the
+        output contains an extra dimension ``t`` which corresponds to the time steps of
+        the simulation and is obtained by concatenating individual
+        ``discretisedfield.Field.to_xarray()`` in the ``micromagneticdata.Drive``. The
+        coordinates of ``t`` give the values of time at given time steps. Similarly,
+        for ``HysteresisDriver``, the extra dimension is ``B_hysteresis``. It has four
+        coordinates, namely ``B_hysteresis``, ``Bx_hysteresis``, ``By_hysteresis``, and
+        ``Bz_hysteresis``. The first represents the norm of the hysteresis field, while
+        the rest three represents the components along the respective axes.
+
+        ``micromagneticdata.Drive.info`` is returned as the output ``xarray.DataArray``
+        attributes, besides the ones derived from
+        ``discretisedfield.Field.to_xarray()``.
+
+        Returns
+        -------
+        xarray.DataArray
+
+            ``micromagneticdata.Drive`` as ``xarray.DataArray``
+
+        Examples
+        --------
+        1. Drive to DataArray
+
+        >>> import os
+        >>> import micromagneticdata as md
+        ...
+        >>> dirname = dirname=os.path.join(os.path.dirname(__file__),
+        ...                                'tests', 'test_sample')
+        >>> drive = md.Drive(name='system_name', number=0, dirname=dirname)
+        >>> xr_drive = drive.to_xarray()
+        >>> xr_drive
+        <xarray.DataArray 'field' (t: 25, x: 20, y: 10, z: 4, comp: 3)>
+        ...
+
+        2. Magnetization in a cell over time for ``TimeDriver``
+
+        >>> xr_drive.isel(x=2, y=2, z=2)
+        <xarray.DataArray 'field' (t: 25, comp: 3)>
+        ...
+
+        """
         if self.info["driver"] == "MinDriver":
             darray = self[0].to_xarray()
         else:

--- a/micromagneticdata/drive.py
+++ b/micromagneticdata/drive.py
@@ -4,9 +4,9 @@ import os
 
 import discretisedfield as df
 import ipywidgets
+import numpy as np
 import ubermagtable as ut
 import ubermagutil.typesystem as ts
-import numpy as np
 import xarray as xr
 
 

--- a/micromagneticdata/drive.py
+++ b/micromagneticdata/drive.py
@@ -422,9 +422,15 @@ class Drive:
         if self.info["driver"] == "MinDriver":
             darray = self[0].to_xarray()
         else:
-            field_darrays = [self[i].to_xarray() for i in range(self.n)]
-            steps = self.table.data[self.x].to_numpy
+            field_darrays = (self[i].to_xarray() for i in range(self.n))
+            steps = self.table.data[self.x].to_numpy()
             darray = xr.concat(field_darrays, dim=self.x).assign_coords({self.x: steps})
+            if self.info["driver"] == "HysteresisDriver":
+                new_dims = {
+                    f"B{i}_hysteresis": self.table.data[f"B{i}_hysteresis"].to_numpy()
+                    for i in "xyz"
+                }
+                darray = darray.expand_dims(dim=new_dims, axis=[1, 2, 3])
 
         return xr.Dataset({"fields": darray, "m0": self.m0.to_xarray()}).assign_attrs(
             **self.info

--- a/micromagneticdata/drive.py
+++ b/micromagneticdata/drive.py
@@ -6,6 +6,7 @@ import discretisedfield as df
 import ipywidgets
 import ubermagtable as ut
 import ubermagutil.typesystem as ts
+import xarray as xr
 
 
 @ts.typesystem(
@@ -414,4 +415,17 @@ class Drive:
         """
         return ipywidgets.IntSlider(
             value=0, min=0, max=self.n - 1, step=1, description=description, **kwargs
+        )
+
+    def to_xarray(self):
+        """Export ``micromagneticdata.Drive`` as ``xarray.Dataset``"""
+        if self.info["driver"] == "MinDriver":
+            darray = self[0].to_xarray()
+        else:
+            field_darrays = [self[i].to_xarray() for i in range(self.n)]
+            steps = self.table.data[self.x].to_numpy
+            darray = xr.concat(field_darrays, dim=self.x).assign_coords({self.x: steps})
+
+        return xr.Dataset({"fields": darray, "m0": self.m0.to_xarray()}).assign_attrs(
+            **self.info
         )

--- a/micromagneticdata/drive.py
+++ b/micromagneticdata/drive.py
@@ -422,15 +422,16 @@ class Drive:
         if self.info["driver"] == "MinDriver":
             darray = self[0].to_xarray()
         else:
-            field_darrays = (self[i].to_xarray() for i in range(self.n))
+            field_darrays = (field.to_xarray() for field in self)
             if self.info["driver"] == "TimeDriver":
-                darray = xr.concat(field_darrays, dim="t").assign_coords(
-                    {"t": self.table.data["t"].to_numpy()}
-                )
+                darray = xr.concat(field_darrays, dim=self.table.data["t"])
             else:
                 darray = xr.concat(field_darrays, dim="B_hysteresis").assign_coords(
                     {
-                        f"B{i}": ("B_hysteresis", self.table.data[f"B{i}_hysteresis"])
+                        f"B{i}_hysteresis": (
+                            "B_hysteresis",
+                            self.table.data[f"B{i}_hysteresis"],
+                        )
                         for i in "xyz"
                     }
                 )

--- a/micromagneticdata/drive.py
+++ b/micromagneticdata/drive.py
@@ -423,20 +423,18 @@ class Drive:
             darray = self[0].to_xarray()
         else:
             field_darrays = (field.to_xarray() for field in self)
-            if self.info["driver"] == "TimeDriver":
-                darray = xr.concat(field_darrays, dim=self.table.data["t"])
-                darray.t.attrs["units"] = self.table.units["t"]
-            else:
-                darray = xr.concat(field_darrays, dim="B_hysteresis").assign_coords(
-                    {
-                        f"B{i}_hysteresis": (
-                            "B_hysteresis",
-                            self.table.data[f"B{i}_hysteresis"],
-                        )
-                        for i in "xyz"
-                    }
-                )
+            darray = xr.concat(field_darrays, dim=self.table.data[self.table.x])
+            darray[self.table.x].attrs["units"] = self.table.units[self.table.x]
+            if self.info["driver"] == "HysteresisDriver":
                 for i in "xyz":
+                    darray = darray.assign_coords(
+                        {
+                            f"B{i}_hysteresis": (
+                                "B_hysteresis",
+                                self.table.data[f"B{i}_hysteresis"],
+                            )
+                        }
+                    )
                     darray[f"B{i}_hysteresis"].attrs["units"] = self.table.units[
                         f"B{i}_hysteresis"
                     ]

--- a/micromagneticdata/drive.py
+++ b/micromagneticdata/drive.py
@@ -418,26 +418,35 @@ class Drive:
     def to_xarray(self, *args, **kwargs):
         """Export ``micromagneticdata.Drive`` as ``xarray.DataArray``
 
-        The method depends on ``discretisedfield.Field.to_xarray()`` and derives the
+        The method depends on ``discretisedfield.Field.to_xarray`` and derives the
         last four dimensions ``x``, ``y``, ``z``, and ``comp`` in the output
-        ``xarray.DataArray`` from it.
+        ``xarray.DataArray`` from it. The arguments and named arguments to this method
+        are passed on to ``discretisedfield.Field.to_xarray``.
 
-        Depending on ``micromagneticdata.Drive.info['driver']``, the dimensions and
-        coordinates of the output changes. For ``MinDriver``, which only contains a
-        single ``discretisedfield.Field``, the value of the single
-        ``discretisedfield.Field.to_xarray()`` is returned. For ``TimeDriver``, the
-        output contains an extra dimension ``t`` which corresponds to the time steps of
-        the simulation and is obtained by concatenating individual
-        ``discretisedfield.Field.to_xarray()`` in the ``micromagneticdata.Drive``. The
-        coordinates of ``t`` give the values of time at given time steps. Similarly,
-        for ``HysteresisDriver``, the extra dimension is ``B_hysteresis``. It has four
-        coordinates, namely ``B_hysteresis``, ``Bx_hysteresis``, ``By_hysteresis``, and
+        Depending on type of driver, the dimensions and coordinates of the output may
+        change. If the number of stored steps in the ``micromagneticdata.Drive`` are
+        more than one, the output contains an extra dimension named after
+        ``micromagneticdata.Drive.table.x`` with proper coordinate values. For the case
+        of ``HysteresisDriver``,  the new dimension has four coordinates, namely
+        ``B_hysteresis``, ``Bx_hysteresis``, ``By_hysteresis``, and
         ``Bz_hysteresis``. The first represents the norm of the hysteresis field, while
-        the rest three represents the components along the respective axes.
+        the rest three represents the components along the respective axes. For
+        ``MinDriver`` with a single ``discretisedfield.Field``, the value of the single
+        ``discretisedfield.Field.to_xarray`` is returned.
 
         ``micromagneticdata.Drive.info`` is returned as the output ``xarray.DataArray``
         attributes, besides the ones derived from
-        ``discretisedfield.Field.to_xarray()``.
+        ``discretisedfield.Field.to_xarray``.
+
+        Parameters
+        ----------
+        args: any
+
+            arguments to ``discretisedfield.Field.to_xarray``
+
+        kwargs: any
+
+            named arguments to ``discretisedfield.Field.to_xarray``
 
         Returns
         -------
@@ -455,15 +464,15 @@ class Drive:
         >>> dirname = dirname=os.path.join(os.path.dirname(__file__),
         ...                                'tests', 'test_sample')
         >>> drive = md.Drive(name='system_name', number=0, dirname=dirname)
-        >>> xr_drive = drive.to_xarray()
+        >>> xr_drive = drive.to_xarray(name='Mag')
         >>> xr_drive
-        <xarray.DataArray 'field' (t: 25, x: 20, y: 10, z: 4, comp: 3)>
+        <xarray.DataArray 'Mag' (t: 25, x: 20, y: 10, z: 4, comp: 3)>
         ...
 
         2. Magnetization in a cell over time for ``TimeDriver``
 
         >>> xr_drive.isel(x=2, y=2, z=2)
-        <xarray.DataArray 'field' (t: 25, comp: 3)>
+        <xarray.DataArray 'Mag' (t: 25, comp: 3)>
         ...
 
         """

--- a/micromagneticdata/drive.py
+++ b/micromagneticdata/drive.py
@@ -430,9 +430,9 @@ class Drive:
         of ``HysteresisDriver``,  the new dimension has four coordinates, namely
         ``B_hysteresis``, ``Bx_hysteresis``, ``By_hysteresis``, and
         ``Bz_hysteresis``. The first represents the norm of the hysteresis field, while
-        the rest three represents the components along the respective axes. For
-        ``MinDriver`` with a single ``discretisedfield.Field``, the value of the single
-        ``discretisedfield.Field.to_xarray`` is returned.
+        the rest three represents the components along the respective axes. For a
+        ``micromagneticdata.Drive`` with a single ``discretisedfield.Field``, the value
+        of the single ``discretisedfield.Field.to_xarray`` is returned.
 
         ``micromagneticdata.Drive.info`` is returned as the output ``xarray.DataArray``
         attributes, besides the ones derived from
@@ -442,11 +442,11 @@ class Drive:
         ----------
         args: any
 
-            arguments to ``discretisedfield.Field.to_xarray``
+            Arguments to ``discretisedfield.Field.to_xarray``
 
         kwargs: any
 
-            named arguments to ``discretisedfield.Field.to_xarray``
+            Named arguments to ``discretisedfield.Field.to_xarray``
 
         Returns
         -------

--- a/micromagneticdata/drive.py
+++ b/micromagneticdata/drive.py
@@ -415,7 +415,7 @@ class Drive:
             value=0, min=0, max=self.n - 1, step=1, description=description, **kwargs
         )
 
-    def to_xarray(self):
+    def to_xarray(self, *args, **kwargs):
         """Export ``micromagneticdata.Drive`` as ``xarray.DataArray``
 
         The method depends on ``discretisedfield.Field.to_xarray()`` and derives the
@@ -468,9 +468,9 @@ class Drive:
 
         """
         if len(self._step_files) == 1:
-            darray = self[0].to_xarray()
+            darray = self[0].to_xarray(*args, **kwargs)
         else:
-            field_darrays = (field.to_xarray() for field in self)
+            field_darrays = (field.to_xarray(*args, **kwargs) for field in self)
             darray = xr.concat(field_darrays, dim=self.table.data[self.table.x])
             darray[self.table.x].attrs["units"] = self.table.units[self.table.x]
             if self.info["driver"] == "HysteresisDriver":

--- a/micromagneticdata/drive.py
+++ b/micromagneticdata/drive.py
@@ -4,7 +4,6 @@ import os
 
 import discretisedfield as df
 import ipywidgets
-import numpy as np
 import ubermagtable as ut
 import ubermagutil.typesystem as ts
 import xarray as xr

--- a/micromagneticdata/drive.py
+++ b/micromagneticdata/drive.py
@@ -467,7 +467,7 @@ class Drive:
         ...
 
         """
-        if self.info["driver"] == "MinDriver":
+        if len(self._step_files) == 1:
             darray = self[0].to_xarray()
         else:
             field_darrays = (field.to_xarray() for field in self)

--- a/micromagneticdata/drive.py
+++ b/micromagneticdata/drive.py
@@ -298,9 +298,7 @@ class Drive:
 
     @property
     def _step_files(self):
-        filenames = glob.iglob(os.path.join(self.path, f"{self.name}*.omf"))
-        for filename in sorted(filenames):
-            yield filename
+        return sorted(glob.iglob(os.path.join(self.path, f"{self.name}*.omf")))
 
     def __getitem__(self, item):
         """Magnetisation field of an individual step.
@@ -325,7 +323,7 @@ class Drive:
         Field(...)
 
         """
-        return df.Field.fromfile(filename=list(self._step_files)[item])
+        return df.Field.fromfile(filename=self._step_files[item])
 
     def __iter__(self):
         """Iterator.

--- a/micromagneticdata/drive.py
+++ b/micromagneticdata/drive.py
@@ -425,6 +425,7 @@ class Drive:
             field_darrays = (field.to_xarray() for field in self)
             if self.info["driver"] == "TimeDriver":
                 darray = xr.concat(field_darrays, dim=self.table.data["t"])
+                darray.t.attrs["units"] = self.table.units["t"]
             else:
                 darray = xr.concat(field_darrays, dim="B_hysteresis").assign_coords(
                     {
@@ -435,7 +436,9 @@ class Drive:
                         for i in "xyz"
                     }
                 )
+                for i in "xyz":
+                    darray[f"B{i}_hysteresis"].attrs["units"] = self.table.units[
+                        f"B{i}_hysteresis"
+                    ]
 
-        return xr.Dataset({"fields": darray, "m0": self.m0.to_xarray()}).assign_attrs(
-            **self.info
-        )
+        return darray.assign_attrs(**self.info)

--- a/micromagneticdata/tests/test_drive.py
+++ b/micromagneticdata/tests/test_drive.py
@@ -89,7 +89,8 @@ class TestDrive:
             assert all(
                 item in drive.to_xarray().attrs.items() for item in drive.info.items()
             )
-            if drive.info["driver"] != "MinDriver":
+            if len(drive._step_files) != 1:
+                assert len(drive.to_xarray()[drive.table.x]) == len(drive._step_files)
                 assert np.allclose(
                     drive.to_xarray()[drive.table.x].values,
                     drive.table.data[drive.table.x].to_numpy(),

--- a/micromagneticdata/tests/test_drive.py
+++ b/micromagneticdata/tests/test_drive.py
@@ -1,12 +1,12 @@
 import os
 import tempfile
-import xarray as xr
-import numpy as np
 
 import discretisedfield as df
 import ipywidgets
+import numpy as np
 import pytest
 import ubermagtable as ut
+import xarray as xr
 
 import micromagneticdata as md
 

--- a/micromagneticdata/tests/test_drive.py
+++ b/micromagneticdata/tests/test_drive.py
@@ -1,5 +1,7 @@
 import os
 import tempfile
+import xarray as xr
+import numpy as np
 
 import discretisedfield as df
 import ipywidgets
@@ -80,3 +82,24 @@ class TestDrive:
     def test_slider(self):
         for drive in self.data:
             assert isinstance(drive.slider(), ipywidgets.IntSlider)
+
+    def test_to_xarray(self):
+        for drive in self.data:
+            assert isinstance(drive.to_xarray(), xr.DataArray)
+            assert all(
+                item in drive.to_xarray().attrs.items() for item in drive.info.items()
+            )
+            if drive.info["driver"] != "MinDriver":
+                assert np.allclose(
+                    drive.to_xarray()[drive.table.x].values,
+                    drive.table.data[drive.table.x].to_numpy(),
+                )
+
+            if drive.info["driver"] == "HysteresisDriver":
+                assert all(
+                    np.allclose(
+                        drive.to_xarray()[f"B{i}_hysteresis"].values,
+                        drive.table.data[f"B{i}_hysteresis"].to_numpy(),
+                    )
+                    for i in "xyz"
+                )


### PR DESCRIPTION
`to_xarray` method returns an `xarray.Dataset` which contains two `xarray.DataArray`s, namely `fields` and `m0`. The `drive.info` metadata is stored in the attributes of the Dataset.