### PR TITLE
Set `valid='norm'` when loading magnetisation data

### DIFF
--- a/micromagneticdata/abstract_drive.py
+++ b/micromagneticdata/abstract_drive.py
@@ -203,6 +203,7 @@ class AbstractDrive(abc.ABC):
         field = df.Field.from_file(filename=self._step_files[item])
         with contextlib.suppress(FileNotFoundError):
             field.mesh.load_subregions(self._m0_path)
+        field.valid = "norm"
         return self._apply_callbacks(field)
 
     def __iter__(self):


### PR DESCRIPTION
The new `valid` option in discretisedfield changes the plotting behaviour. To retain the old behaviour we should set `valid='norm'` when loading magnetisation data. This resembles the behaviour of interpreting zero norm cells as invalid and should not have any undesirable side effects.