### PR TITLE
Fix doctests for to_xarray

### DIFF
--- a/micromagneticdata/abstract_drive.py
+++ b/micromagneticdata/abstract_drive.py
@@ -343,14 +343,12 @@ class AbstractDrive(abc.ABC):
         >>> drive = md.Drive(name='system_name', number=0, dirname=dirname)
         >>> xr_drive = drive.to_xarray(name='Mag')
         >>> xr_drive
-        <xarray.DataArray 'Mag' (t: 25, x: 20, y: 10, z: 4, vdims: 3)>
-        ...
+        <xarray.DataArray 'Mag' (t: 25, x: 20, y: 10, z: 4, vdims: 3)>...
 
         2. Magnetization in a cell over time for ``TimeDriver``
 
         >>> xr_drive.isel(x=2, y=2, z=2)
-        <xarray.DataArray 'Mag' (t: 25, vdims: 3)>
-        ...
+        <xarray.DataArray 'Mag' (t: 25, vdims: 3)>...
 
         """
         if len(self._step_files) == 1:


### PR DESCRIPTION
The representation of the new xarray releases contains additional data (memory size of the array) in the first line